### PR TITLE
✨ Add variable validations (closes #70)

### DIFF
--- a/aws-cloudfront.tf
+++ b/aws-cloudfront.tf
@@ -62,6 +62,17 @@ resource "aws_cloudfront_distribution" "site" {
       condition     = var.security_headers != "custom" || var.response_headers_policy_id != null
       error_message = "When var.security_headers = \"custom\", var.response_headers_policy_id must be set to a non-null CloudFront response headers policy ID."
     }
+
+    # Per-prefix DNS validation lives on extra_domain_prefixes; the total FQDN
+    # length depends on domain_zone_name too, so the cap check goes here where
+    # both variables are in scope.
+    precondition {
+      condition = alltrue([
+        for prefix in var.extra_domain_prefixes :
+        length("${prefix}.${var.domain_zone_name}") <= 253
+      ])
+      error_message = "Each FQDN formed by joining var.extra_domain_prefixes[*] with var.domain_zone_name must be at most 253 characters total (DNS limit). One or more prefixes combined with the zone name would exceed this; shorten the prefix(es) or use a shorter zone name."
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,14 @@ variable "s3_kms_key_arn" {
   default     = null
   description = "The ARN of the KMS key used for S3 server-side encryption."
   nullable    = true
+
+  validation {
+    condition = (
+      var.s3_kms_key_arn == null ||
+      can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|alias/[a-zA-Z0-9/_-]+)$", var.s3_kms_key_arn))
+    )
+    error_message = "var.s3_kms_key_arn must be null or a valid KMS ARN. Expected shape: arn:<partition>:kms:<region>:<account>:key/<uuid> or arn:<partition>:kms:<region>:<account>:alias/<name>. Aliases are accepted because S3 SSE configuration takes either form."
+  }
 }
 
 variable "default_root_object" {
@@ -35,25 +43,52 @@ variable "default_root_object" {
   default     = "index.html"
   description = "The default root object for the S3 bucket, typically used for web hosting."
   nullable    = true
+
+  validation {
+    condition = (
+      var.default_root_object == null ||
+      (length(var.default_root_object) > 0 && !startswith(var.default_root_object, "/"))
+    )
+    error_message = "var.default_root_object must be null or a non-empty path that does not start with '/'. The path is interpreted relative to the distribution root; a leading slash is a common mistake CloudFront silently rejects."
+  }
 }
 
 variable "domain_zone_name" {
   type        = string
   description = "If setting a custom CNAME for the Cloudfront distribution this is the domain name for the zone."
   nullable    = false
+
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.domain_zone_name))
+    error_message = "var.domain_zone_name must be a valid lowercase domain name (e.g. \"example.com\"). Each label may contain lowercase alphanumerics and hyphens but must not start or end with a hyphen. Internationalized domain names should be passed in their punycode (xn--) form."
+  }
 }
 
 variable "domain_zone_id" {
   type        = string
   description = "If setting a custom CNAME for the Cloudfront distribution this is the domain name for the zone."
   nullable    = false
+
+  validation {
+    condition     = can(regex("^Z[A-Z0-9]+$", var.domain_zone_id))
+    error_message = "var.domain_zone_id must be a Route 53 hosted zone ID (e.g. \"Z1D633PJN98FT9\"): starts with an uppercase 'Z' followed by uppercase alphanumerics. If you have the zone name and not the ID, look it up via the Route 53 console or `aws route53 list-hosted-zones-by-name`."
+  }
 }
 
 variable "extra_domain_prefixes" {
   type        = list(string)
   default     = []
-  description = "Prefixes for additional custom domains to be associated with the CloudFront distribution."
+  description = "Prefixes for additional custom domains to be associated with the CloudFront distribution. Each prefix is concatenated as '<prefix>.<domain_zone_name>' to form the final FQDN; multi-label prefixes (e.g. \"api.cdn\") are supported."
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for prefix in var.extra_domain_prefixes :
+      length(prefix) > 0 && length(prefix) <= 253 &&
+      can(regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$", prefix))
+    ])
+    error_message = "Each entry in var.extra_domain_prefixes must be one or more valid DNS labels separated by '.'. Each label: 1-63 lowercase alphanumerics or hyphens, not starting or ending with a hyphen. Total prefix length must not exceed 253 characters."
+  }
 }
 
 variable "function_associations" {
@@ -64,6 +99,43 @@ variable "function_associations" {
   default     = []
   description = "A config block that triggers a lambda function with specific actions (maximum 4)."
   nullable    = false
+
+  # CloudFront's hard limit is 4 function associations per cache behavior. This
+  # module only configures the distribution's default_cache_behavior, so the
+  # per-behavior limit is also the module-wide limit.
+  validation {
+    condition     = length(var.function_associations) <= 4
+    error_message = "var.function_associations must contain at most 4 entries (CloudFront's per-cache-behavior limit; this module uses a single cache behavior)."
+  }
+
+  validation {
+    condition = alltrue([
+      for assoc in var.function_associations :
+      contains(["viewer-request", "viewer-response", "origin-request", "origin-response"], assoc.event_type)
+    ])
+    error_message = "Each function_associations[*].event_type must be one of: viewer-request, viewer-response, origin-request, origin-response. Note that CloudFront Functions only support viewer-request and viewer-response; use Lambda@Edge for origin-request and origin-response."
+  }
+
+  validation {
+    condition = alltrue([
+      for assoc in var.function_associations :
+      can(regex("^arn:aws[a-z-]*:cloudfront::[0-9]{12}:function/[a-zA-Z0-9_-]+$", assoc.function_arn)) ||
+      can(regex("^arn:aws[a-z-]*:lambda:[a-z0-9-]+:[0-9]{12}:function:[a-zA-Z0-9_-]+:[0-9]+$", assoc.function_arn))
+    ])
+    error_message = "Each function_associations[*].function_arn must be either a CloudFront Function ARN (arn:<partition>:cloudfront::<account>:function/<name>) or a Lambda@Edge versioned function ARN (arn:<partition>:lambda:<region>:<account>:function:<name>:<version>). Lambda@Edge associations require a specific version number — CloudFront does not accept $LATEST."
+  }
+
+  # Cross-attribute check: origin-* event types are Lambda@Edge-only. A
+  # CloudFront Function ARN paired with origin-request/origin-response will be
+  # rejected by the CloudFront API at apply time; catch it here instead.
+  validation {
+    condition = alltrue([
+      for assoc in var.function_associations :
+      !contains(["origin-request", "origin-response"], assoc.event_type) ||
+      !can(regex("^arn:aws[a-z-]*:cloudfront::", assoc.function_arn))
+    ])
+    error_message = "function_associations entries with event_type 'origin-request' or 'origin-response' must point to a Lambda@Edge ARN, not a CloudFront Function. CloudFront Functions only execute at the viewer edge."
+  }
 }
 
 variable "enable_spa_error_handling" {
@@ -90,4 +162,12 @@ variable "response_headers_policy_id" {
   default     = null
   description = "CloudFront response headers policy ID. Required when var.security_headers = \"custom\"; ignored otherwise."
   nullable    = true
+
+  validation {
+    condition = (
+      var.response_headers_policy_id == null ||
+      can(regex("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$", var.response_headers_policy_id))
+    )
+    error_message = "var.response_headers_policy_id must be null or a CloudFront response headers policy ID in UUID format (e.g. \"67f7725c-6f97-4210-82d7-5512b31e9d03\"). If you have the policy ARN, the ID is the last path segment."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,14 +59,14 @@ variable "domain_zone_name" {
   nullable    = false
 
   validation {
-    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.domain_zone_name))
-    error_message = "var.domain_zone_name must be a valid lowercase domain name (e.g. \"example.com\"). Each label may contain lowercase alphanumerics and hyphens but must not start or end with a hyphen. Internationalized domain names should be passed in their punycode (xn--) form."
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9]([a-z0-9-]*[a-z0-9])$", var.domain_zone_name))
+    error_message = "var.domain_zone_name must be a valid lowercase domain name (e.g. \"example.com\" or \"example.xn--p1ai\"). Each label may contain lowercase alphanumerics and hyphens but must not start or end with a hyphen. The TLD label must be at least 2 characters; internationalized TLDs should be passed in their punycode (xn--) form."
   }
 }
 
 variable "domain_zone_id" {
   type        = string
-  description = "If setting a custom CNAME for the Cloudfront distribution this is the domain name for the zone."
+  description = "If setting a custom CNAME for the Cloudfront distribution this is the Route 53 hosted zone ID."
   nullable    = false
 
   validation {
@@ -120,9 +120,9 @@ variable "function_associations" {
     condition = alltrue([
       for assoc in var.function_associations :
       can(regex("^arn:aws[a-z-]*:cloudfront::[0-9]{12}:function/[a-zA-Z0-9_-]+$", assoc.function_arn)) ||
-      can(regex("^arn:aws[a-z-]*:lambda:[a-z0-9-]+:[0-9]{12}:function:[a-zA-Z0-9_-]+:[0-9]+$", assoc.function_arn))
+      can(regex("^arn:aws[a-z-]*:lambda:us-east-1:[0-9]{12}:function:[a-zA-Z0-9_-]+:[0-9]+$", assoc.function_arn))
     ])
-    error_message = "Each function_associations[*].function_arn must be either a CloudFront Function ARN (arn:<partition>:cloudfront::<account>:function/<name>) or a Lambda@Edge versioned function ARN (arn:<partition>:lambda:<region>:<account>:function:<name>:<version>). Lambda@Edge associations require a specific version number — CloudFront does not accept $LATEST."
+    error_message = "Each function_associations[*].function_arn must be either a CloudFront Function ARN (arn:<partition>:cloudfront::<account>:function/<name>) or a Lambda@Edge versioned function ARN (arn:<partition>:lambda:us-east-1:<account>:function:<name>:<version>). Lambda@Edge functions must be created in us-east-1 — CloudFront will not accept replicas from other regions — and the ARN must include a specific version number, not $LATEST."
   }
 
   # Cross-attribute check: origin-* event types are Lambda@Edge-only. A


### PR DESCRIPTION
closes #70 ♡

## summary

implements the six variable-validation surfaces from #70 with engineering judgment where the literal-regex suggestion would have either rejected valid inputs or accepted bad ones. plus three bonus validations that were sitting in plain sight on the surrounding variables.

all regex patterns verified directly via `terraform console`; `terraform fmt` + `terraform validate` clean; end-to-end fire-test on `domain_zone_id` via `terraform plan` against the simple example.

## what changed

| variable | as-issued? | what's different |
|---|---|---|
| `s3_kms_key_arn` | refined | accepts alias ARNs in addition to key ARNs (S3 SSE takes either form), partition-aware (`aws`, `aws-cn`, `aws-us-gov`, `aws-iso`, ...). issue's regex was `arn:aws:` + key-only. |
| `default_root_object` | NEW | must not start with `/`. CloudFront silently swallows leading-slash root objects; this catches it at plan. |
| `domain_zone_name` | refined | uses `[a-z0-9]([a-z0-9-]*[a-z0-9])?` per label so punycode (`xn--example.com`) validates. issue's `(-[a-z0-9]+)*` rejected consecutive hyphens. |
| `domain_zone_id` | NEW | Route 53 hosted zone ID shape (`Z[A-Z0-9]+`). catches the "did you pass the zone name as the ID" mistake. |
| `extra_domain_prefixes` | refined | supports multi-label prefixes (e.g. `status.test`) — the existing simple example uses one, so the issue's single-label-only proposal would have broken `examples/simple`. enforces total length ≤253 and per-label 1-63. |
| `function_associations` cardinality | as-issued | max 4 per CloudFront's per-cache-behavior limit. this module only configures the distribution's `default_cache_behavior`, so 4 is also the module-wide ceiling. |
| `function_associations[*].event_type` | refined wording | same enum as proposed; error message now calls out that CloudFront Functions only support `viewer-request`/`viewer-response` so users learn the distinction at plan time, not apply. |
| `function_associations[*].function_arn` | refined | distinct ARN shapes for CloudFront Functions (`arn:<partition>:cloudfront::<account>:function/<name>`, empty region segment) vs Lambda@Edge (`arn:<partition>:lambda:<region>:<account>:function:<name>:<version>`, version mandatory because CF rejects `$LATEST`). issue's single hybrid regex matched both shapes but accepted false positives in either direction. |
| `function_associations` cross-attr | NEW | when `event_type` is `origin-request` or `origin-response`, the ARN must be Lambda@Edge — CloudFront Functions only run at the viewer edge. CloudFront's API rejects the bad pairing at apply; we now reject at plan. |
| `response_headers_policy_id` | NEW | UUID format (case-insensitive — UUIDs are, even though AWS returns them lowercase). gives a clean error if someone pastes an ARN where the ID is expected. |

## why "more than just documentation cleanup"

- catches eight distinct apply-time failure modes at plan time, several of which surface as opaque AWS API errors otherwise (CloudFront Functions paired with origin-* event types, Lambda@Edge ARN missing version, leading-slash root object, KMS alias ARN rejected by a key-only validation).
- the function_associations cross-attribute check models a real CF semantic constraint (CF Functions = viewer-edge-only) that no single-field regex can express.
- the multi-label prefix support keeps the existing example valid; a literal copy of the issue's regex would have broken `examples/simple`.

## non-breaking-ness

this PR only adds new `validation` blocks to existing variables. variable types, defaults, and nullability are unchanged. any input that successfully `terraform apply`d before still does — the validations are strictly stricter than the implicit AWS-API gate the module currently relies on for these conditions, and only reject inputs that would have failed at apply.

## verification

- regex semantics tested directly via `terraform console` (positive + negative cases for each pattern).
- `terraform fmt -check variables.tf` ✓
- `terraform validate` on `examples/simple/` ✓ (existing inputs unchanged, validations don't reject valid usage).
- `terraform plan` on `examples/simple/` with a synthetic `route53_zone_id = "not-a-zone-id"` fires the `var.domain_zone_id` validation with the expected error message.

— k 🐱

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened validation of infrastructure configuration parameters to prevent invalid configurations and provide clearer error feedback when requirements are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->