### PR TITLE
feat: additional origins, ordered cache behaviors, apex domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ will find a compatible version automatically.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 6.0 |
 
 ### Providers
@@ -146,6 +146,7 @@ will find a compatible version automatically.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_origins"></a> [additional_origins](#input_additional_origins) | Extra custom (HTTPS-only, TLSv1.2) origins, e.g. an API Gateway regional endpoint. origin_path may carry the API stage (e.g. "/api"). | <pre>list(object({<br/>    origin_id   = string<br/>    domain_name = string<br/>    origin_path = optional(string, "")<br/>  }))</pre> | `[]` | no |
 | <a name="input_context"></a> [context](#input_context) | Shared Context from Ben's terraform-null-context | <pre>object({<br/>    attributes     = list(string)<br/>    dns_namespace  = string<br/>    environment    = string<br/>    instance       = string<br/>    instance_short = string<br/>    namespace      = string<br/>    region         = string<br/>    region_short   = string<br/>    role           = string<br/>    role_short     = string<br/>    project        = string<br/>    tags           = map(string)<br/>  })</pre> | n/a | yes |
 | <a name="input_default_root_object"></a> [default_root_object](#input_default_root_object) | The default root object for the S3 bucket, typically used for web hosting. | `string` | `"index.html"` | no |
 | <a name="input_domain_zone_id"></a> [domain_zone_id](#input_domain_zone_id) | If setting a custom CNAME for the Cloudfront distribution this is the Route 53 hosted zone ID. | `string` | n/a | yes |
@@ -154,9 +155,11 @@ will find a compatible version automatically.
 | <a name="input_extra_domain_prefixes"></a> [extra_domain_prefixes](#input_extra_domain_prefixes) | Prefixes for additional custom domains to be associated with the CloudFront distribution. Each prefix is concatenated as '<prefix>.\<domain_zone_name>' to form the final FQDN; multi-label prefixes (e.g. "api.cdn") are supported. | `list(string)` | `[]` | no |
 | <a name="input_function_associations"></a> [function_associations](#input_function_associations) | A config block that triggers a lambda function with specific actions (maximum 4). | <pre>set(object({<br/>    event_type   = string<br/>    function_arn = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_name"></a> [name](#input_name) | The name of the site, used for naming resources and identifiers. | `string` | `"site"` | no |
+| <a name="input_ordered_cache_behaviors"></a> [ordered_cache_behaviors](#input_ordered_cache_behaviors) | Path-routed behaviors ahead of the default S3 behavior, evaluated in list order. Defaults suit an API origin: Managed-CachingDisabled + Managed-AllViewerExceptHostHeader. | <pre>list(object({<br/>    path_pattern             = string<br/>    target_origin_id         = string<br/>    allowed_methods          = optional(list(string), \["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"\])<br/>    cached_methods           = optional(list(string), \["GET", "HEAD"\])<br/>    cache_policy_id          = optional(string, "4135ea2d-6df8-44a3-9df3-4b5a84be39ad")<br/>    origin_request_policy_id = optional(string, "b689b0a8-53d0-40ab-baf2-68738e2966ac")<br/>  }))</pre> | `[]` | no |
 | <a name="input_response_headers_policy_id"></a> [response_headers_policy_id](#input_response_headers_policy_id) | CloudFront response headers policy ID. Required when var.security_headers = "custom"; ignored otherwise. | `string` | `null` | no |
 | <a name="input_s3_kms_key_arn"></a> [s3_kms_key_arn](#input_s3_kms_key_arn) | The ARN of the KMS key used for S3 server-side encryption. | `string` | `null` | no |
 | <a name="input_security_headers"></a> [security_headers](#input_security_headers) | Response headers policy strategy for the CloudFront distribution. One of: "managed" (attach AWS's Managed-SecurityHeadersPolicy — HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, X-XSS-Protection), "custom" (attach the policy at var.response_headers_policy_id — required when this is set), or "none" (no response headers policy attached). | `string` | `"managed"` | no |
+| <a name="input_use_apex_domain"></a> [use_apex_domain](#input_use_apex_domain) | Serve the zone apex (var.domain_zone_name itself) as the distribution's primary alias instead of the label-derived subdomain. | `bool` | `false` | no |
 
 ### Outputs
 

--- a/aws-cloudfront.tf
+++ b/aws-cloudfront.tf
@@ -17,6 +17,22 @@ resource "aws_cloudfront_distribution" "site" {
     origin_access_control_id = aws_cloudfront_origin_access_control.site.id
   }
 
+  dynamic "origin" {
+    for_each = { for o in var.additional_origins : o.origin_id => o }
+    content {
+      origin_id   = origin.value.origin_id
+      domain_name = origin.value.domain_name
+      origin_path = origin.value.origin_path
+
+      custom_origin_config {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
   default_cache_behavior {
     target_origin_id           = module.label_site.id
     compress                   = true
@@ -32,6 +48,24 @@ resource "aws_cloudfront_distribution" "site" {
         event_type   = function_association.value.event_type
         function_arn = function_association.value.function_arn
       }
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = var.ordered_cache_behaviors
+    content {
+      path_pattern             = ordered_cache_behavior.value.path_pattern
+      target_origin_id         = ordered_cache_behavior.value.target_origin_id
+      allowed_methods          = ordered_cache_behavior.value.allowed_methods
+      cached_methods           = ordered_cache_behavior.value.cached_methods
+      cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
+      origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
+      # Same viewer-side response headers policy as the default behavior so the
+      # security headers strategy (var.security_headers) applies to API
+      # responses too.
+      response_headers_policy_id = local.response_headers_policy_id
+      viewer_protocol_policy     = "redirect-to-https"
+      compress                   = true
     }
   }
 

--- a/examples/api-behaviors/ctx.tf
+++ b/examples/api-behaviors/ctx.tf
@@ -1,0 +1,9 @@
+module "context" {
+  source    = "bendoerr-terraform-modules/context/null"
+  version   = "0.5.1"
+  namespace = var.namespace
+  role      = "cloudfront-s3-example"
+  region    = "us-east-1"
+  project   = "api-behaviors"
+  long_dns  = true
+}

--- a/examples/api-behaviors/main.tf
+++ b/examples/api-behaviors/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Route53 zones can often be in a different account. They cost $0.50 to exist
+# so if we are trying to keep costs down we may want to only have the minimum
+# needed to function.
+provider "aws" {
+  region  = "us-east-1"
+  alias   = "route53"
+  profile = var.route53_profile
+}
+
+module "cloudfront_with_s3_origin" {
+  source = "../.."
+
+  context = module.context.shared
+  name    = "app"
+
+  domain_zone_name = var.route53_zone_name
+  domain_zone_id   = var.route53_zone_id
+
+  # Serve the label-derived subdomain; set true to serve the zone apex instead.
+  use_apex_domain = false
+
+  # Route /api/* to an API Gateway regional endpoint on the same distribution,
+  # ahead of the default S3 behavior. origin_path carries the API stage.
+  additional_origins = [{
+    origin_id   = "api"
+    domain_name = "example-api.execute-api.us-east-1.amazonaws.com"
+    origin_path = "/api"
+  }]
+  ordered_cache_behaviors = [
+    { path_pattern = "/api/*", target_origin_id = "api" },
+  ]
+
+  providers = {
+    aws.route53 = aws.route53
+  }
+}

--- a/examples/api-behaviors/outputs.tf
+++ b/examples/api-behaviors/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_id" {
+  value       = module.cloudfront_with_s3_origin.s3_bucket_id
+  description = "The ID of the S3 bucket used for the CloudFront origin."
+}
+
+output "cloudfront_distribution_id" {
+  value       = module.cloudfront_with_s3_origin.cloudfront_distribution_id
+  description = "The ID of the CloudFront distribution."
+}
+
+output "cloudfront_distribution_alias_domain_name" {
+  value       = module.cloudfront_with_s3_origin.cloudfront_distribution_alias_domain_name
+  description = "The primary alias domain name of the CloudFront distribution (the zone apex when use_apex_domain = true)."
+}

--- a/examples/api-behaviors/variables.tf
+++ b/examples/api-behaviors/variables.tf
@@ -1,0 +1,22 @@
+variable "namespace" {
+  type        = string
+  description = "The context namespace"
+}
+
+variable "route53_profile" {
+  type        = string
+  description = "Dedicated AWS profile for accessing Route53"
+  nullable    = false
+}
+
+variable "route53_zone_id" {
+  type        = string
+  description = "The ZoneID for the Route53 Zone"
+  nullable    = false
+}
+
+variable "route53_zone_name" {
+  type        = string
+  description = "The Name of the Route53 Zone"
+  nullable    = false
+}

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "label_site" {
 }
 
 locals {
-  default_alias = format("%s.%s", module.label_site.dns_name, var.domain_zone_name)
+  default_alias = var.use_apex_domain ? var.domain_zone_name : format("%s.%s", module.label_site.dns_name, var.domain_zone_name)
   extra_aliases = formatlist("%s.%s", var.extra_domain_prefixes, var.domain_zone_name)
 
   # AWS-published static ID for the managed `SecurityHeadersPolicy`. Hardcoded rather than

--- a/variables.tf
+++ b/variables.tf
@@ -171,3 +171,48 @@ variable "response_headers_policy_id" {
     error_message = "var.response_headers_policy_id must be null or a CloudFront response headers policy ID in UUID format (e.g. \"67f7725c-6f97-4210-82d7-5512b31e9d03\"). If you have the policy ARN, the ID is the last path segment."
   }
 }
+
+variable "use_apex_domain" {
+  type        = bool
+  default     = false
+  nullable    = false
+  description = "Serve the zone apex (var.domain_zone_name itself) as the distribution's primary alias instead of the label-derived subdomain."
+}
+
+variable "additional_origins" {
+  type = list(object({
+    origin_id   = string
+    domain_name = string
+    origin_path = optional(string, "")
+  }))
+  default     = []
+  nullable    = false
+  description = "Extra custom (HTTPS-only, TLSv1.2) origins, e.g. an API Gateway regional endpoint. origin_path may carry the API stage (e.g. \"/api\")."
+
+  validation {
+    condition     = length(var.additional_origins) == length(distinct([for o in var.additional_origins : o.origin_id]))
+    error_message = "additional_origins origin_id values must be unique."
+  }
+}
+
+variable "ordered_cache_behaviors" {
+  type = list(object({
+    path_pattern             = string
+    target_origin_id         = string
+    allowed_methods          = optional(list(string), ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"])
+    cached_methods           = optional(list(string), ["GET", "HEAD"])
+    cache_policy_id          = optional(string, "4135ea2d-6df8-44a3-9df3-4b5a84be39ad")
+    origin_request_policy_id = optional(string, "b689b0a8-53d0-40ab-baf2-68738e2966ac")
+  }))
+  default     = []
+  nullable    = false
+  description = "Path-routed behaviors ahead of the default S3 behavior, evaluated in list order. Defaults suit an API origin: Managed-CachingDisabled + Managed-AllViewerExceptHostHeader."
+
+  validation {
+    condition = alltrue([
+      for b in var.ordered_cache_behaviors :
+      contains([for o in var.additional_origins : o.origin_id], b.target_origin_id)
+    ])
+    error_message = "Every ordered_cache_behaviors target_origin_id must match an additional_origins origin_id."
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
+  # 1.9.0 floor: var.ordered_cache_behaviors' validation cross-references
+  # var.additional_origins, which requires Terraform >= 1.9.
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source                = "hashicorp/aws"


### PR DESCRIPTION
## why

the **bendobundles** app needs its API on the *same origin* as the static site: the admin session cookie is `SameSite=Strict` and the frontend fetches relative paths (`/api/*`, `/admin/api/*`) — a separate api subdomain would break both. so the one CloudFront distribution has to front the S3 site *and* an API Gateway regional endpoint, and serve the zone apex. the module currently only knows its single S3 origin and the label-derived subdomain alias. (´,,•ω•,,)

## what

three new variables, all defaulting to today's behavior (zero-diff for existing consumers):

- **`use_apex_domain`** (bool, default `false`) — serve the zone apex (`var.domain_zone_name` itself) as the primary alias instead of `<label>.<zone>`. flows through everything derived from `local.default_alias`: distribution aliases, ACM cert domain + SANs, DNS validation records, the route53 A/AAAA alias, and the `cloudfront_distribution_alias_domain_name` output.
- **`additional_origins`** (list, default `[]`) — extra custom origins (HTTPS-only, TLSv1.2), e.g. an API Gateway regional endpoint. `origin_path` can carry the API stage (`"/api"`). origin_ids validated unique.
- **`ordered_cache_behaviors`** (list, default `[]`) — path-routed behaviors ahead of the default S3 behavior, evaluated in list order. each `target_origin_id` is validated (plan-time) to reference an `additional_origins` entry. behaviors reuse the module's `local.response_headers_policy_id`, so the `security_headers` strategy applies to API responses too.

plus `examples/api-behaviors/` mirroring `examples/simple`, showing `/api/*` routed to an API Gateway origin.

## managed-policy UUIDs (before anyone squints at them)

the two hardcoded UUIDs in `ordered_cache_behaviors` defaults are **AWS-published static managed-policy IDs**, same pattern as the module's existing hardcoded `Managed-SecurityHeadersPolicy` ID in `main.tf`:

- `4135ea2d-6df8-44a3-9df3-4b5a84be39ad` = `Managed-CachingDisabled`
- `b689b0a8-53d0-40ab-baf2-68738e2966ac` = `Managed-AllViewerExceptHostHeader`

hardcoded (not `data`-resolved) so callers don't need extra `cloudfront:List*` permissions — exactly the reasoning already documented in `main.tf`.

## note: required_version bump

`ordered_cache_behaviors`' validation cross-references `var.additional_origins`, which needs terraform >= 1.9 (and `optional()` needs >= 1.3), so `required_version` moved `>= 0.13` → `>= 1.9.0`. the old floor would have been a lie with these vars in place; happy to discuss if you'd rather gate it differently, old man.

## validation i actually ran

- `terraform fmt -recursive -check` — clean
- `terraform init -backend=false && terraform validate` — `Success!` on `examples/simple` AND `examples/api-behaviors` (root-dir standalone validate fails identically on unmodified `main` — the known `configuration_aliases` quirk, pre-existing, not this PR)
- negative test: a `target_origin_id` not present in `additional_origins` fails at plan with `Every ordered_cache_behaviors target_origin_id must match an additional_origins origin_id.` ✓
- apex plan check: with `use_apex_domain = true`, ACM cert renders `domain_name = "example.com"` + apex SAN + apex validation record ✓
- `terraform-docs v0.24.0` (`markdown table --indent 3 --output-mode inject`) + `mdformat 0.7.17` — README regenerated with the repo's own pre-commit chain (markdown is mdformat's, not prettier's, per `.prettierignore`)
- `tflint 0.63.1` with the repo `.tflint.hcl` (terraform preset "all" + aws ruleset) — clean on root and both examples

## checklist

- [ ] release: consumers pin git ref until tagged

cc @oldmanbendobot — review when you can, gramps ♡ your distribution learns new tricks today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional additional origins and ordered, path-based cache behaviors.
  * Added an option to use the domain apex as the primary alias.
  * Expanded the example setup to demonstrate API routing and Route53 integration.

* **Bug Fixes**
  * Improved alias handling so apex and non-apex domains are both supported correctly.

* **Documentation**
  * Updated setup requirements and input documentation to reflect the newer Terraform version and new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->